### PR TITLE
Add initial bazel configs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 !.clang-format
 !.gitignore
 
+# Bazel output directories
+bazel-*
+
 # Build artifacts. These files should not be in our repo. Even if we have to
 # use pre-built third-party libraries, they should be introduced via as a bazel
 # external repo. 

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,20 @@
+load("@rules_license//rules:license.bzl", "license")
+
+license(
+    name = "license",
+    package_name = "lockqueue/test",
+    copyright_notice = "Copyright © 2014 The lockqueue-test Authors. All rights reserved.",
+    license_kinds = [
+        "@rules_license//licenses/spdx:Apache-2.0",
+    ],
+    license_text = "LICENSE",
+)
+
+exports_files(["LICENSE"])
+
+filegroup(
+  name = "srcs",
+  srcs = glob(["**/*"], exclude=["bazel-*", ".*"]),
+  applicable_licenses = [":license"],
+  visibility = ["//tools/oss-compliance:__pkg__"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,12 @@
+workspace(name = "lockqueue")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_license",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
+        "https://github.com/bazelbuild/rules_license/releases/download/0.0.3/rules_license-0.0.3.tar.gz",
+    ],
+    sha256 = "00ccc0df21312c127ac4b12880ab0f9a26c1cff99442dc6c5a331750360de3c3",
+)

--- a/experimental/BUILD
+++ b/experimental/BUILD
@@ -1,0 +1,6 @@
+package(default_applicable_licenses = ["//:license"])
+
+cc_binary(
+  name = "hello_world",
+  srcs = ["hello_world.cc"],
+)

--- a/experimental/hello_world.cc
+++ b/experimental/hello_world.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+  std::cout << "Hello, world!" << '\n';
+  return 0;
+}

--- a/tools/oss-compliance/BUILD
+++ b/tools/oss-compliance/BUILD
@@ -1,0 +1,12 @@
+load("@rules_license//rules:compliance.bzl", "check_license")
+
+check_license(
+    name = "check_srcs",
+    check_conditions = False,
+    copyright_notices = "srcs_copyrights.txt",
+    license_texts = "srcs_licenses.txt",
+    report = "srcs_report",
+    deps = [
+        "//:srcs",
+    ],
+)


### PR DESCRIPTION
This PR mainly focuses on the OSS-license compliance checks provided by
bazel.